### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ management — you can optimize productivity and costs while building a modern, 
 - `Product Documentation`_
 
 .. |ga| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#ga-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#ga-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-eventarc.svg
    :target: https://pypi.org/project/google-cloud-eventarc/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-eventarc.svg
@@ -80,4 +80,4 @@ Next Steps
    APIs that we cover.
 
 .. _Eventarc Product documentation:  https://cloud.google.com/eventarc/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.