### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "eventarc",
     "name_pretty": "Eventarc",
     "product_documentation": "https://cloud.google.com/eventarc/",
-    "client_documentation": "https://googleapis.dev/python/eventarc/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/eventarc/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ management — you can optimize productivity and costs while building a modern, 
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-eventarc.svg
    :target: https://pypi.org/project/google-cloud-eventarc/
 .. _Eventarc: https://cloud.google.com/eventarc
-.. _Client Library Documentation: https://googleapis.dev/python/eventarc/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/eventarc/latest
 .. _Product Documentation:  https://cloud.google.com/eventarc/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.